### PR TITLE
language edits + more in the description

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -4,29 +4,29 @@ slug: /
 
 # Introduction
 
-ClayStack is a decentralized liquid staking protocol that unlocks the liquidity of staked assets in Proof-of-Stake (PoS) networks. When users deposit their stakable tokens in ClayStack’s smart contracts, it issues csTokens that are fully backed, fully fungible value-accrual tokens. These tokens increase in value as they start receiving the staking rewards from the network.
+ClayStack is a decentralized liquid staking protocol that unlocks the liquidity of staked assets in Proof-of-Stake (PoS) networks. When users deposit their stakable tokens in ClayStack’s smart contracts, it issues csTokens that are fully backed, fully fungible, value-accrual tokens. These tokens increase in value as they start receiving the staking rewards from the network.
 
 Users can also utilize these tokens as base capital to participate in other DeFi protocols. The combined yield from staking rewards and participating in DeFi compounds over time increasing the net profit for the user.
 
-ClayStack is accessible at https://app.claystack.com
+Access ClayStack at https://app.claystack.com.
 
-### csToken
+### csTokens
 
-csTokens are standard ERC20 tokens that represents the claim to both the underlying Token and the staking rewards, thus csTokens continuously appreciate in value with respect to the base Token, abstracting away for the complexity of staking, claiming, and re-staking.
+csTokens are standard ERC20 tokens that represent the claim to both the underlying staked tokens and the staking rewards. csTokens continuously appreciate in value with respect to the base token, abstracting away the complexity of staking, claiming and re-staking.
 
-Users can opt to sell their csTokens instead of unstaking, in that way avoiding unstaking fees or waiting for "unbonding" period unstil their tokens are available for withdrawal.
+Users can opt to sell their csTokens instead of unstaking. As a result, they avoid the unstaking fees and don't need to wait for the "unbonding" period to get over to get access to their tokens.
 
 ### Staking
 
-The process of staking involves the transfer of the underlying token to ClayStack's smart contract, which in turn will mint csTokens at the current exchange rate and will thereafter stake the underlying tokens on trusted validators. Most protocols will employ a delegate staking system, thus ensuring the safety of the funds for the users.
+The process of staking involves the transfer of the underlying tokens to ClayStack's smart contracts, which in turn mints csTokens at the current exchange rate and thereafter stakes the underlying tokens via trusted validators. Most protocols employ a delegate staking system, thus ensuring the safety of the funds for the users.
 
 ### Standard Unstaking
 
-ClayStack's contract offers a direct unstaking mechanism, which leverages the PoS chain unstaking system. In most cases, users will need to wait a period of time before their tokens are made available. Depending on the protocol, this "unbonding" period can range from a few days to 1 year.
+ClayStack's contract offers a direct unstaking mechanism, which leverages the PoS chain's unstaking system. In most cases, users will need to wait a period of time before their tokens are made available. Depending on the protocol, this "unbonding" period can range from a few days to several months.
 
 ### Flash Exit
 
-ClayStack's contract offers a unique feature acting as a liquidity pool, where users can unstake and immediately receive the underlying Token. The feature removes the need for any waiting time, yet there may be fees and limits on amounts.
+ClayStack's contract offers a unique feature acting as a liquidity pool, where users can unstake and immediately receive the underlying tokens. The feature removes the need for any waiting time, yet there may be fees and limits on withdrawable amounts.
 
 [//]: # (- [ClayStack LitePaper]&#40;#&#41;)
 


### PR DESCRIPTION
1. Not sure about this. What exactly are we doing here? "Most protocols employ a delegate staking system, thus ensuring the safety of the funds for the users."
If we are using a delegate staking system, should we not just change it to, "We employ a delegate staking system to ensure the safety of our users' funds."

2. In line 25, changed from 1 year to several months; 1 year comes off as a lifetime whereas several months is a bit more ambiguous 

3. Need to remove the whitepaper link