### PR TITLE
Update staking.md

### DIFF
--- a/docs/faq/staking.md
+++ b/docs/faq/staking.md
@@ -1,34 +1,34 @@
 # Staking FAQ
 
 ### How does staking work?
-Within the PoS ecosystem, validators take the role of validating transactions and in return they receive tokens as rewards. ClayStack abstracts the process to allow anyone to stake without having to run validating nodes or without the need for staking expertise. Through a staking smart contract, the user is able to stake token and get back a liquid token that increases in value based on the staking rewards.
+Within the PoS ecosystem, validators take on the role of validating transactions and in return they receive tokens as rewards. But to run a validator node requires technical expertise. ClayStack abstracts the process to allow anyone to stake without having to run validating nodes or without the need for staking expertise. Through a staking smart contract, the user is able to stake their tokens and receive liquid tokens that increase in value based on the staking rewards.
 
 ### How does unstaking work?
-Having your csToken, you can unstake anytime. At the moment of unstaking, your csTokens will be burned and instead your unstake claim will start. You will NOT receive your tokens right away, but will depend on each protocol's unbonding period. Once the period is over, you need to return and claim your tokens, then they will appear in your wallet.
+With your csToken, you can unstake anytime. When you unstake, your csTokens are burned as the unstake claim period starts. You are NOT able to receive your tokens right away, as the unbonding period varies for each protocol. Once the period is over, you are able to claim your tokens and then then they appear in your wallet.
 
 ### What is liquid staking?
-At the moment of staking, ClayStack gives you a [csToken](#what-is-the-cstoken) in return. This csToken is fully liquid and gives you new possibilities while still enjoying rewards from staking.
+When you stake with ClayStack, it gives you a [csToken](#what-is-the-cstoken) in return. This csToken is fully liquid and gives you new possibilities while still enjoying rewards from staking.
 
 ### Who holds my assets?
 When you stake through ClayStack, the protocol will delegate the token in the chain's stake manager contract, where it will accrue rewards. The stake is spread across different validating nodes, but the validators have no access to the tokens. Those assets are protected by both the chain's Stake Manager contract and ClayStack's contract.
 
 ### What is the csToken?
 
-csTokens are a standard ERC20 token that represents the claim to both the underlying Token and the staking rewards, thus csTokens continuously appreciate in value with respect to the base Token.
+csTokens are standard ERC20 tokens that represent the claim to both the underlying token and the staking rewards. Thus, csTokens continuously appreciate in value with respect to the base Token.
 
 ### What is the value of a csToken?
 
-A csToken is worth more than a simple Token because its value includes all the accrued rewards overtime. Holding a csToken like csMATIC is like holding MATIC, but in addition receives continuous staking rewards.
+A csToken is worth more than a simple Token because its value includes all the accrued rewards overtime. Holding a csToken like csMATIC is like holding MATIC, but in addition it receives continuous staking rewards.
 
 ### How frequently will I get rewards?
-Unlike other protocols, rewards are constantly accrued. There is no need to claim rewards to re-stake rewards. ClayStack's protocol does it by design. Your csToken increases in value passively.
+Unlike other protocols, rewards are constantly accrued. There is no need to claim rewards to re-stake them. ClayStack protocol does it by design. Your csToken increases in value passively.
 
 ### How often does the exchange rate change?
-Albeit rewards being accrued constantly, the exchange rate may vary less often. You can expect price changes 2-3 times a day.
+Albeit rewards accrue constantly, the exchange rate may vary less often. You can expect price changes 2-3 times a day.
 
 ### How can I use my csTokens?
 
-Just holding csTokens already is giving you passive income from the staking rewards. You can always sell your csTokens, trade them and soon we will start seeing new use cases emerging like the use of csTokens in lending protocols.
+Just holding csTokens already is giving you passive income from the staking rewards. You can always trade your csTokens. We will collaborate with other protocols to expand the use-cases for the csTokens, such as using them as deposits on lending protocols. 
 
 ### What is Flash Exit?
 
@@ -42,4 +42,4 @@ Flash Exit lets users instantly withdraw their native tokens while in standard u
 No. The moment you unstake, the csToken is burned and your unstake claim starts with the protocol.
 
 ### What are the risks of liquid staking?
-When you stake, to start you are still exposed to the underlying assets, so relative to stable coins, a csToken still represent a risky investment. Additionally, there are smart contract risks and some protocols carry a slashing risk.
+When you stake you are still exposed to the underlying assets. And relative to stablecoins, a csToken is still represent a risky investment. Additionally, there are smart contract risks and some protocols carry a slashing risk.


### PR DESCRIPTION
1) Lines 1-23: language changes 
2) Line 24: changed to "There is no need to claim rewards to re-stake them." 
3) Line 27: language change 
4) Line 31: changed to "We will collaborate with other protocols to expand the use-cases for the csTokens, such as using them as deposits on lending protocols. " please let's not use soon - it's a bit deceptive 
5) Line 45: not sure if we want to keep this: And relative to stablecoins, a csToken is still represent a risky investment. csTokens represent the value of the underlying tokens and thus all the risk is derived from the underlying tokens themselves; would suggest rephrasing this to: "When you stake, you are exposed to the volatility of the underlying token. Even when you get csTokens, they inherit this risk from the underlying tokens. Additionally, there are smart contract risks and some protocols carry a slashing risk."